### PR TITLE
Bug fix: equalFilePath "C:\\" "C:" == False

### DIFF
--- a/System/FilePath/Internal.hs
+++ b/System/FilePath/Internal.hs
@@ -686,11 +686,8 @@ joinPath = foldr combine ""
 equalFilePath :: FilePath -> FilePath -> Bool
 equalFilePath a b = f a == f b
     where
-        f x | isWindows = dropTrailSlash $ map toLower $ normalise x
-            | otherwise = dropTrailSlash $ normalise x
-
-        dropTrailSlash x | length x >= 2 && hasTrailingPathSeparator x = init x
-                         | otherwise = x
+        f x | isWindows = dropTrailingPathSeparator $ map toLower $ normalise x
+            | otherwise = dropTrailingPathSeparator $ normalise x
 
 
 -- | Contract a filename, based on a relative path.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
   * Bug fix: on Windows, `dropTrailingPathSeparator "/"` now returns `"/"`
     unchanged, instead of the normalised `"\\"`.
 
+  * Bug fix: on Windows, `equalFilePath "C:\\" "C:"` now retuns `False`,
+    instead of `True`.
+
 ## 1.3.0.2  *Mar 2014*
 
   * Bundled with GHC 7.8.1


### PR DESCRIPTION
This started out as a simple refactoring of `equalFilePath`, and later turned
out to also fix a small bug.

The refactoring is: use `dropTrailingPathSeparator` instead of the custom
function `dropTrailSlash`.

A difference between these two functions is that `dropTrailingPathSeparator`
potentially removes multiple trailing slashes, whereas `dropTrailSlash` only
removes the last one. But since we `normalise` the FilePath first, which
removes superfluous pathSeparators, this difference does not matter to us.

Another difference is that `dropTrailingPathSeparator` does not drop slashes
when the FilePath isDrive, but `dropTrailSlash` does:

dropTrailSlash "C:\" == "C:"
dropTrailSlash "C:\\" == "C:\"

dropTrailingPathSeparator "C:\" == "C:\"
dropTrailingPathSeparator "C:\\" == "C:\\"

As a result, equalFilePath of drives on Windows changes slightly:

Before:
equalFilePath "C:\" "C:" == True
equalFilePath "C:\\" "C:" == False

After:
equalFilePath "C:\" "C:" == False
equalFilePath "C:\\" "C:" == False

This can be considered a bug fix, since "C:\foo" and "C:foo", and thus "C:\"
and "C:", are not the same thing.
