### PR TITLE
Bug fix: isDrive "" == False

### DIFF
--- a/System/FilePath/Internal.hs
+++ b/System/FilePath/Internal.hs
@@ -422,8 +422,9 @@ hasDrive = not . null . takeDrive
 -- > Posix:   isDrive "/foo" == False
 -- > Windows: isDrive "C:\\" == True
 -- > Windows: isDrive "C:\\foo" == False
+-- >          isDrive "" == False
 isDrive :: FilePath -> Bool
-isDrive = null . dropDrive
+isDrive x = not (null x) && null (dropDrive x)
 
 
 ---------------------------------------------------------------------

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
   * Bundled with GHC 7.10.1
 
+  * Bug fix: `isDrive ""` now retuns `False`, instead of `True`.
+
   * Bug fix: on Windows, `dropTrailingPathSeparator "/"` now returns `"/"`
     unchanged, instead of the normalised `"\\"`.
 


### PR DESCRIPTION
isDrive is only called from `dropTrailingPathSeparator` and `combineAlways`.
Both times occur after a check if the argument is not empty (i.e. null for
combineAlways, and hasTrailingPathSeparator for dropTrailingPathSeparator). So
this change is safe.
