### PR TITLE
Bug fix: isValid "\\\\\\foo" == False

### DIFF
--- a/System/FilePath/Internal.hs
+++ b/System/FilePath/Internal.hs
@@ -807,14 +807,16 @@ badElements = ["CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5
 -- > Windows: isValid "c:\\test\\prn.txt" == False
 -- > Windows: isValid "c:\\nul\\file" == False
 -- > Windows: isValid "\\\\" == False
+-- > Windows: isValid "\\\\\\foo" == False
 isValid :: FilePath -> Bool
 isValid "" = False
 isValid _ | isPosix = True
 isValid path =
         not (any (`elem` badCharacters) x2) &&
         not (any f $ splitDirectories x2) &&
-        not (length path >= 2 && all isPathSeparator path)
+        not (length x1 >= 2 && all isPathSeparator x1)
     where
+        x1 = head (splitPath path)
         x2 = dropDrive path
         f x = map toUpper (dropExtensions x) `elem` badElements
 
@@ -831,10 +833,13 @@ isValid path =
 -- > Windows: makeValid "c:\\test\\prn.txt" == "c:\\test\\prn_.txt"
 -- > Windows: makeValid "c:\\test/prn.txt" == "c:\\test/prn_.txt"
 -- > Windows: makeValid "c:\\nul\\file" == "c:\\nul_\\file"
+-- > Windows: makeValid "\\\\\\foo" == "\\\\drive"
 makeValid :: FilePath -> FilePath
 makeValid "" = "_"
 makeValid path | isPosix = path
-makeValid x | length x >= 2 && all isPathSeparator x = take 2 x ++ "drive"
+makeValid xs | length x >= 2 && all isPathSeparator x = take 2 x ++ "drive"
+    where
+        x = head (splitPath xs)
 makeValid path = joinDrive drv $ validElements $ validChars pth
     where
         (drv,pth) = splitDrive path

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
   * Bug fix: on Windows, `dropTrailingPathSeparator "/"` now returns `"/"`
     unchanged, instead of the normalised `"\\"`.
 
+  * Bug fix: on Windows, `isValid "\\\\\\foo"` now returns `False`, instead
+    of `True`.
+
 ## 1.3.0.2  *Mar 2014*
 
   * Bundled with GHC 7.8.1


### PR DESCRIPTION
Share name can not start with a slash.
