### PR TITLE
Refactor splitDirectories

### DIFF
--- a/System/FilePath/Internal.hs
+++ b/System/FilePath/Internal.hs
@@ -643,15 +643,7 @@ splitPath x = [drive | drive /= ""] ++ f path
 -- > Valid x => joinPath (splitDirectories x) `equalFilePath` x
 -- > splitDirectories "" == []
 splitDirectories :: FilePath -> [FilePath]
-splitDirectories path =
-        if hasDrive path then head pathComponents : f (tail pathComponents)
-        else f pathComponents
-    where
-        pathComponents = splitPath path
-
-        f = map g
-        g x = if null res then x else res
-            where res = takeWhile (not . isPathSeparator) x
+splitDirectories = map dropTrailingPathSeparator . splitPath
 
 
 -- | Join path elements back together.


### PR DESCRIPTION
Use `dropTrailingPathSeparator` instead of the custom function `g` to remove
trailing path separators from FilePath components generated with `splitPath`.

Since `dropTrailingPathSeparator` does not change FilePath components
for which isDrive is True, it is no longer necessary to handle the first
FilePath component in a special way.
