### PR TITLE
Refer to `makeAbsolute` instead of `canonicalizePath` in docs

### DIFF
--- a/System/FilePath/Internal.hs
+++ b/System/FilePath/Internal.hs
@@ -729,8 +729,8 @@ equalFilePath a b = f a == f b
 
 -- | Contract a filename, based on a relative path.
 --
---   There is no corresponding @makeAbsolute@ function, instead use
---   @System.Directory.canonicalizePath@ which has the same effect.
+--   The corresponding @makeAbsolute@ function can be found in
+--   @System.Directory@.
 --
 -- >          makeRelative "/directory" "/directory/file.ext" == "file.ext"
 -- >          Valid x => makeRelative (takeDirectory x) x `equalFilePath` takeFileName x


### PR DESCRIPTION
Since directory-1.2.2.0, there is a `makeAbsolute` function that works as a more reliable counterpart to `makeRelative`.