### PR TITLE
Do not normalise ./-foo to -foo (GHC Trac 12674)

### DIFF
--- a/tests/TestGen.hs
+++ b/tests/TestGen.hs
@@ -406,6 +406,7 @@ tests =
     ,("P.normalise \"/\" == \"/\"", property $ P.normalise "/" == "/")
     ,("P.normalise \"bob/fred/.\" == \"bob/fred/\"", property $ P.normalise "bob/fred/." == "bob/fred/")
     ,("P.normalise \"//home\" == \"/home\"", property $ P.normalise "//home" == "/home")
+    ,("P.normalise \"./-bob\" == \"./-bob\"", property $ P.normalise "./-bob" == "./-bob")
     ,("P.isValid \"\" == False", property $ P.isValid "" == False)
     ,("W.isValid \"\" == False", property $ W.isValid "" == False)
     ,("P.isValid \"\\0\" == False", property $ P.isValid "\0" == False)


### PR DESCRIPTION
This PR fixes GHC Trac 12674 (https://ghc.haskell.org/trac/ghc/ticket/12674).

A lot of standart programs accept files starting with a hyphen in the current directory only if they are written as `./-foo.ext`
GHC normalises the file names rather early at the processing. Till now a file name `./-foo.hs` is normalised to `-foo.hs` and regarded as a flag. Even if we split up flags from file names at this point, GHC does not work with filenames beginning with a hyphen. Every time GHC passes such a file  (eg `-foo.o`) to an external program (eg preprocessor, linker etc) we have to readd the `./` directory. 
By changing the _normalise_ function, GHC will be able to process input files beginning with hyphens without additional changes.