### PR TITLE
Bump base lower bound

### DIFF
--- a/filepath.cabal
+++ b/filepath.cabal
@@ -48,7 +48,7 @@ library
         System.FilePath.Windows
 
     build-depends:
-        base >= 4 && < 4.15
+        base >= 4.9 && < 4.15
 
     ghc-options: -Wall
 


### PR DESCRIPTION
You don't test older GHCs, so better to be honest.

I'm quite sure that `Use pure` commit broke tests on older GHCs, it's just matter of time when the library would be broken as well.