### PR TITLE
Bump base upper bound to 4.16

### DIFF
--- a/filepath.cabal
+++ b/filepath.cabal
@@ -48,7 +48,7 @@ library
         System.FilePath.Windows
 
     build-depends:
-        base >= 4.9 && < 4.16
+        base >= 4.9 && < 4.17
 
     ghc-options: -Wall
 


### PR DESCRIPTION
Context: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4082#note_300462