### PR TITLE
Fix regression in System.FilePath.Windows.normalise

### DIFF
--- a/System/FilePath/Internal.hs
+++ b/System/FilePath/Internal.hs
@@ -963,7 +963,7 @@ normalise filepath =
            then singleton _period
            else joinDrive d p
 
-    addPathSeparator = isDirPath filepath
+    addPathSeparator = isDirPath pth
       && not (hasTrailingPathSeparator result)
       && not (isRelativeDrive drv)
 


### PR DESCRIPTION
W.normalise "//." would return "\\\\.\\" instead of "\\\\.".

This is a regression since the 1.4.100.0 rewrite.

Fixes #187

----

@bgamari 