### PR TITLE
Migrate from checkers to quickcheck-classes-base

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,20 +14,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.7', '9.0.2', '9.2.5', '9.2.6', '9.4.4']
+        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.7', '9.0.2', '9.2.7', '9.4.5', '9.6.1']
         cabal: ['3.8.1.0']
         include:
           - os: macOS-latest
-            ghc: '9.2.6'
+            ghc: '9.4.5'
             cabal: '3.8.1.0'
           - os: macOS-latest
-            ghc: '9.4.4'
+            ghc: '9.6.1'
             cabal: '3.8.1.0'
           - os: windows-latest
-            ghc: '9.2.6'
+            ghc: '9.4.5'
             cabal: '3.8.1.0'
           - os: windows-latest
-            ghc: '9.4.4'
+            ghc: '9.6.1'
             cabal: '3.8.1.0'
     steps:
     - uses: actions/checkout@v3

--- a/filepath.cabal
+++ b/filepath.cabal
@@ -182,10 +182,10 @@ test-suite abstract-filepath
   build-depends:
     , base
     , bytestring  >=0.11.3.0
-    , checkers    ^>=0.5.6
     , deepseq
     , filepath
     , QuickCheck  >=2.7      && <2.15
+    , quickcheck-classes-base ^>=0.6.2
 
 benchmark bench-filepath
   default-language: Haskell2010

--- a/tests/abstract-filepath/Arbitrary.hs
+++ b/tests/abstract-filepath/Arbitrary.hs
@@ -12,27 +12,15 @@ import Data.ByteString ( ByteString )
 import qualified Data.ByteString as ByteString
 import Test.QuickCheck
 
-import Test.QuickCheck.Checkers
-
-
 
 instance Arbitrary OsString where
   arbitrary = fmap fromJust $ encodeUtf <$> listOf filepathChar
 
-instance EqProp OsString where
-  (=-=) = eq
-
 instance Arbitrary PosixString where
   arbitrary = fmap fromJust $ Posix.encodeUtf <$> listOf filepathChar
 
-instance EqProp PosixString where
-  (=-=) = eq
-
 instance Arbitrary WindowsString where
   arbitrary = fmap fromJust $ Windows.encodeUtf <$> listOf filepathChar
-
-instance EqProp WindowsString where
-  (=-=) = eq
 
 
 newtype NonNullString = NonNullString { nonNullString :: String }

--- a/tests/abstract-filepath/OsPathSpec.hs
+++ b/tests/abstract-filepath/OsPathSpec.hs
@@ -21,8 +21,7 @@ import Control.Exception
 import Data.ByteString ( ByteString )
 import qualified Data.ByteString as BS
 import Test.QuickCheck
-import Test.QuickCheck.Checkers
-import qualified Test.QuickCheck.Classes as QC
+import qualified Test.QuickCheck.Classes.Base as QC
 import GHC.IO.Encoding.UTF8 ( mkUTF8 )
 import GHC.IO.Encoding.UTF16 ( mkUTF16le )
 import GHC.IO.Encoding ( setFileSystemEncoding )
@@ -33,6 +32,7 @@ import qualified Data.ByteString.Char8 as C
 import qualified System.OsPath.Data.ByteString.Short.Word16 as BS16
 import qualified System.OsPath.Data.ByteString.Short as SBS
 import Data.Char ( ord )
+import Data.Proxy ( Proxy(..) )
 
 import Arbitrary
 
@@ -233,24 +233,20 @@ tests =
     )
 
 
-  ] ++ testBatch (QC.ord (\(a :: OsPath) -> pure a))
-    ++ testBatch (QC.monoid (undefined :: OsPath))
+  ] ++ QC.lawsProperties (QC.ordLaws (Proxy @OsPath))
+    ++ QC.lawsProperties (QC.monoidLaws (Proxy @OsPath))
 
-    ++ testBatch (QC.ord (\(a :: OsString) -> pure a))
-    ++ testBatch (QC.monoid (undefined :: OsString))
+    ++ QC.lawsProperties (QC.ordLaws (Proxy @OsString))
+    ++ QC.lawsProperties (QC.monoidLaws (Proxy @OsString))
 
-    ++ testBatch (QC.ord (\(a :: WindowsString) -> pure a))
-    ++ testBatch (QC.monoid (undefined :: WindowsString))
+    ++ QC.lawsProperties (QC.ordLaws (Proxy @WindowsString))
+    ++ QC.lawsProperties (QC.monoidLaws (Proxy @WindowsString))
 
-    ++ testBatch (QC.ord (\(a :: PosixString) -> pure a))
-    ++ testBatch (QC.monoid (undefined :: PosixString))
+    ++ QC.lawsProperties (QC.ordLaws (Proxy @PosixString))
+    ++ QC.lawsProperties (QC.monoidLaws (Proxy @PosixString))
 
-    ++ testBatch (QC.ord (\(a :: PlatformString) -> pure a))
-    ++ testBatch (QC.monoid (undefined :: PlatformString))
-
--- | Allows to insert a 'TestBatch' into a Spec.
-testBatch :: TestBatch -> [(String, Property)]
-testBatch (_, tests') = tests'
+    ++ QC.lawsProperties (QC.ordLaws (Proxy @PlatformString))
+    ++ QC.lawsProperties (QC.monoidLaws (Proxy @PlatformString))
 
 
 padEven :: ByteString -> ByteString


### PR DESCRIPTION
When built against GHC 9.6, `checkers` cause a cyclic dependency:
`filepath:tests` -> `checkers-0.6` -> `semigroupoids-6` -> `hashable-1.4.2.0` -> `filepath`.

`quickcheck-classes-base` is a suitable replacement, which (for sufficiently new GHC) depends on boot packages only.