### PR TITLE
Bump base bound to <4.20

### DIFF
--- a/filepath.cabal
+++ b/filepath.cabal
@@ -103,7 +103,7 @@ library
 
   default-language: Haskell2010
   build-depends:
-    , base              >=4.9      && <4.19
+    , base              >=4.9      && <4.20
     , bytestring        >=0.11.3.0
     , deepseq
     , exceptions


### PR DESCRIPTION
For GHC 9.8.