### PR TITLE
Improve deprecation warnings wrt #209

### DIFF
--- a/Generate.hs
+++ b/Generate.hs
@@ -24,6 +24,7 @@ main = do
         , "{-# LANGUAGE CPP #-}"
         , "{-# OPTIONS_GHC -Wno-name-shadowing #-}"
         , "{-# OPTIONS_GHC -Wno-orphans #-}"
+        , "{-# OPTIONS_GHC -Wno-deprecations #-}"
         ,"module TestGen(tests) where"
         ,"import TestUtil"
         ,"#if !MIN_VERSION_base(4,11,0)"

--- a/System/FilePath/Internal.hs
+++ b/System/FilePath/Internal.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 -- This template expects CPP definitions for:
 --     MODULE_NAME = Posix | Windows

--- a/System/OsPath/Common.hs
+++ b/System/OsPath/Common.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 -- This template expects CPP definitions for:
 --
 --     WINDOWS defined? = no            | yes              | no

--- a/System/OsPath/Data/ByteString/Short.hs
+++ b/System/OsPath/Data/ByteString/Short.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 -- |
 -- Module      : System.OsPath.Data.ByteString.Short
 -- Copyright   : (c) Duncan Coutts 2012-2013, Julian Ospald 2022

--- a/System/OsPath/Data/ByteString/Short/Word16.hs
+++ b/System/OsPath/Data/ByteString/Short/Word16.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 
-{-# OPTIONS_GHC -fno-warn-name-shadowing -fexpose-all-unfoldings #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing -fexpose-all-unfoldings -Wno-deprecations #-}
 
 -- |
 -- Module      :  System.OsPath.Data.ByteString.Short.Word16

--- a/System/OsPath/Encoding.hs
+++ b/System/OsPath/Encoding.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
 module System.OsPath.Encoding
   (
   -- * Types

--- a/System/OsPath/Encoding/Internal.hs
+++ b/System/OsPath/Encoding/Internal.hs
@@ -5,6 +5,7 @@
            , CPP
   #-}
 {-# OPTIONS_GHC  -funbox-strict-fields #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 #if __GLASGOW_HASKELL__ < 908
 module System.OsPath.Encoding.Internal {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-} where

--- a/System/OsPath/Encoding/Internal.hs
+++ b/System/OsPath/Encoding/Internal.hs
@@ -2,11 +2,55 @@
            , BangPatterns
            , TypeApplications
            , MultiWayIf
+           , CPP
   #-}
 {-# OPTIONS_GHC  -funbox-strict-fields #-}
 
-
+#if __GLASGOW_HASKELL__ < 908
 module System.OsPath.Encoding.Internal {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-} where
+#else
+module System.OsPath.Encoding.Internal
+  ( {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    EncodingException (..),
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    cWcharsToChars_UCS2,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    decodeWithBasePosix,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    decodeWithBaseWindows,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    encodeWithBasePosix,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    encodeWithBaseWindows,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    mkUcs2le,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    mkUTF16le_b,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    showEncodingException,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    ucs2le,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    ucs2le_decode,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    ucs2le_DF,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    ucs2le_EF,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    ucs2le_encode,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    utf16le_b,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    utf16le_b_decode,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    utf16le_b_DF,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    utf16le_b_EF,
+    {-# DEPRECATED "Use System.OsString.Encoding.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
+    utf16le_b_encode,
+  )
+where
+#endif
 
 import qualified System.OsPath.Data.ByteString.Short as BS8
 import qualified System.OsPath.Data.ByteString.Short.Word16 as BS16

--- a/System/OsPath/Internal.hs
+++ b/System/OsPath/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE UnliftedFFITypes #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module System.OsPath.Internal where
 

--- a/System/OsPath/Types.hs
+++ b/System/OsPath/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module System.OsPath.Types
   (

--- a/System/OsString.hs
+++ b/System/OsString.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 -- |
 -- Module      :  OsString
 -- Copyright   :  © 2021 Julian Ospald

--- a/System/OsString/Common.hs
+++ b/System/OsString/Common.hs
@@ -1,6 +1,7 @@
 {- HLINT ignore "Unused LANGUAGE pragma" -}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 -- This template expects CPP definitions for:
 --     MODULE_NAME = Posix | Windows
 --     IS_WINDOWS  = False | True

--- a/System/OsString/Internal.hs
+++ b/System/OsString/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE UnliftedFFITypes #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module System.OsString.Internal {-# DEPRECATED "Use System.OsString.Internal from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-} where
 

--- a/System/OsString/Internal/Types.hs
+++ b/System/OsString/Internal/Types.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module System.OsString.Internal.Types {-# DEPRECATED "Use System.OsString.Internal.Types from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
   (

--- a/System/OsString/Types.hs
+++ b/System/OsString/Types.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 module System.OsString.Types {-# DEPRECATED "Use System.OsString.Types from os-string >= 2.0.0 package instead. This module will be removed in filepath >= 1.5." #-}
   (
     WindowsString

--- a/bench/BenchFilePath.hs
+++ b/bench/BenchFilePath.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Main where
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,11 @@
 
 _Note: below all `FilePath` values are unquoted, so `\\` really means two backslashes._
 
-## 1.4.200.0 *Jul 2023*
+## 1.4.200.1 *Dec 2023*
+
+* Improve deprecation warnings for GHC 9.8+ wrt [#209](https://github.com/haskell/filepath/issues/209)
+
+## 1.4.200.0 *Nov 2023*
 
 * deprecate `OsString` modules
 

--- a/filepath.cabal
+++ b/filepath.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               filepath
-version:            1.4.200.0
+version:            1.4.200.1
 
 -- NOTE: Don't forget to update ./changelog.md
 license:            BSD-3-Clause

--- a/tests/TestUtil.hs
+++ b/tests/TestUtil.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module TestUtil(
     module TestUtil,

--- a/tests/abstract-filepath/Arbitrary.hs
+++ b/tests/abstract-filepath/Arbitrary.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Arbitrary where
 

--- a/tests/abstract-filepath/EncodingSpec.hs
+++ b/tests/abstract-filepath/EncodingSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module EncodingSpec where
 

--- a/tests/abstract-filepath/OsPathSpec.hs
+++ b/tests/abstract-filepath/OsPathSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module OsPathSpec where
 

--- a/tests/bytestring-tests/Properties/Common.hs
+++ b/tests/bytestring-tests/Properties/Common.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 -- We are happy to sacrifice optimizations in exchange for faster compilation,
 -- but need to test rewrite rules. As one can check using -ddump-rule-firings,

--- a/tests/filepath-tests/TestGen.hs
+++ b/tests/filepath-tests/TestGen.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 module TestGen(tests) where
 import TestUtil
 #if !MIN_VERSION_base(4,11,0)


### PR DESCRIPTION
@tbidne can you test this?

Something else I noticed: building filepath itself throws many deprecation warnings. Can we ignore all those package internal deprecation warnings somehow without causing a lot of work?