### PR TITLE
Bump base upper bound to <4.23

### DIFF
--- a/filepath.cabal
+++ b/filepath.cabal
@@ -91,7 +91,7 @@ library
 
   default-language: Haskell2010
   build-depends:
-    , base              >=4.12.0.0      && <4.22
+    , base              >=4.12.0.0      && <4.23
     , bytestring        >=0.11.3.0
     , deepseq
     , exceptions


### PR DESCRIPTION
Allowing GHC 9.14.