### PR TITLE
Switch from template-haskell to template-haskell-quasiquoter and -lift

### DIFF
--- a/System/OsPath/Common.hs
+++ b/System/OsPath/Common.hs
@@ -124,20 +124,34 @@ import System.OsString.Windows as PS
 import Data.Bifunctor ( bimap )
 import qualified System.OsPath.Windows.Internal as C
 import GHC.IO.Encoding.UTF16 ( mkUTF16le )
+#if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift
+    ( Lift(..), lift )
+import Language.Haskell.TH.QuasiQuoter
+    ( QuasiQuoter (..) )
+#else
+import Language.Haskell.TH.Syntax
+    ( Lift(..), lift )
 import Language.Haskell.TH.Quote
     ( QuasiQuoter (..) )
-import Language.Haskell.TH.Syntax
-    ( Lift (..), lift )
+#endif
 import GHC.IO.Encoding.Failure ( CodingFailureMode(..) )
 import Control.Monad ( when )
 
 #elif defined(POSIX)
 import GHC.IO.Encoding.Failure ( CodingFailureMode(..) )
 import Control.Monad ( when )
+#if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift
+    ( Lift(..), lift )
+import Language.Haskell.TH.QuasiQuoter
+    ( QuasiQuoter (..) )
+#else
+import Language.Haskell.TH.Syntax
+    ( Lift(..), lift )
 import Language.Haskell.TH.Quote
     ( QuasiQuoter (..) )
-import Language.Haskell.TH.Syntax
-    ( Lift (..), lift )
+#endif
 
 import GHC.IO.Encoding.UTF8 ( mkUTF8 )
 import System.OsPath.Types

--- a/System/OsPath/Internal.hs
+++ b/System/OsPath/Internal.hs
@@ -15,10 +15,17 @@ import Control.Monad.Catch
     ( MonadThrow )
 import Data.ByteString
     ( ByteString )
+#if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift
+    ( Lift(..), lift )
+import Language.Haskell.TH.QuasiQuoter
+    ( QuasiQuoter (..) )
+#else
+import Language.Haskell.TH.Syntax
+    ( Lift(..), lift )
 import Language.Haskell.TH.Quote
     ( QuasiQuoter (..) )
-import Language.Haskell.TH.Syntax
-    ( Lift (..), lift )
+#endif
 import GHC.IO.Encoding.Failure ( CodingFailureMode(..) )
 
 import System.OsString.Internal.Types

--- a/filepath.cabal
+++ b/filepath.cabal
@@ -95,8 +95,16 @@ library
     , bytestring        >=0.11.3.0
     , deepseq
     , exceptions
-    , template-haskell
     , os-string         >=2.0.1
+  -- template-haskell-lift was added as a boot library in GHC-9.14
+  -- once we no longer wish to backport releases to older major releases,
+  -- this conditional can be dropped
+  if impl(ghc < 9.14)
+      build-depends: template-haskell
+  elif impl(ghc)
+      build-depends:
+        , template-haskell-lift >=0.1 && <0.2
+        , template-haskell-quasiquoter >=0.1 && <0.2
 
   ghc-options:      -Wall
 


### PR DESCRIPTION
We switch our dependency on template-haskell to a dependency on template-haskell-lift. This smaller library is more stabler and if we can remove the template-haskell dependency from all boot libraries then template-haskell will be much easier to re-install since it no longer needs to be in GHC's dependency closure.

For more information see the GHC proposal that introduced this library: https://github.com/ghc-proposals/ghc-proposals/pull/696

This GHC MR tests this PR against GHC-HEAD: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14978